### PR TITLE
Streamline configuration

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -25,12 +25,49 @@ addEventListener("load", () => {
         },
         {
           type: "symbol",
+          id: "waterway-labels",
+          source: "openmaptiles",
+          "source-layer": "water_name",
+          filter: ["==", ["geometry-type"], "LineString"],
+          layout: {
+            "symbol-placement": "line",
+            "text-field": ["get", "name"],
+            "text-font": ["Americana-Italic"],
+          },
+        },
+        {
+          type: "symbol",
+          id: "waterbody-labels",
+          source: "openmaptiles",
+          "source-layer": "water_name",
+          filter: ["!=", ["geometry-type"], "LineString"],
+          layout: {
+            "text-field": ["get", "name"],
+            "text-font": ["Americana-Italic"],
+          },
+        },
+        {
+          type: "symbol",
           id: "place-labels",
           source: "openmaptiles",
           "source-layer": "place",
           layout: {
             "text-field": ["get", "name"],
             "text-font": ["Americana-Bold"],
+          },
+        },
+        {
+          type: "symbol",
+          id: "boundary-edge-labels",
+          source: "openmaptiles",
+          "source-layer": "boundary",
+          layout: {
+            "symbol-placement": "line",
+            "text-field": maplibregl.Diplomat.getLocalizedCountryNameExpression(
+              ["get", "adm0_l"],
+            ),
+            "text-font": ["Americana"],
+            "text-size": 10,
           },
         },
       ],
@@ -51,10 +88,9 @@ addEventListener("load", () => {
       "text-field",
       maplibregl.Diplomat.localizedNameWithLocalGloss,
     );
-    let locales = maplibregl.Diplomat.getLocales();
-    let style = map.getStyle();
-    map.localizeLayers(style.layers, locales);
-    map.setStyle(style);
+    map.localizeStyle(maplibregl.Diplomat.getLocales(), {
+      uppercaseCountryNames: true,
+    });
   });
 
   addEventListener("hashchange", (event) => {
@@ -65,11 +101,9 @@ addEventListener("load", () => {
       new URL(event.newURL),
     );
     if (oldLanguage !== newLanguage) {
-      let locales = maplibregl.Diplomat.getLocales();
-      console.log(`Changed to ${locales}`);
-      let style = map.getStyle();
-      map.localizeLayers(style.layers, locales);
-      map.setStyle(style);
+      map.localizeStyle(maplibregl.Diplomat.getLocales(), {
+        uppercaseCountryNames: true,
+      });
     }
   });
 });


### PR DESCRIPTION
Replaced `localizeLayers()` with a more encapsulated `localizeStyle()` that can automatically manipulate all the layers and upgrade unlocalizable layers. Added the rest of the country code conversion functionality from OSM Americana that the documentation teased about.

This PR includes the following backwards-incompatible changes compared to v0.1.0:

* Replaced `maplibregl.Map.prototype.localizeLayers()` with `maplibregl.Map.prototype.localizeStyle()`. The raw `maplibre.Diplomat.localizeLayers()` remains available for more fine-grained control.
* Removed the undocumented `countryNamesByCode` global variable in favor of `maplibregl.Diplomat.getGlobalStateForLocalization()` for setting up country name localization and `maplibregl.Diplomat.getLocalizedCountryNameExpression()` for getting an expression for getting a country name.

Fixes #3.