### PR TITLE
Maximize and minimize locale codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,23 @@ Example:
 maplibregl.Diplomat.getLocales().includes("en");
 ```
 
+### `maplibregl.Diplomat.getRelatedLanguageTags()`
+
+Returns an array of the language tags related to the given language tag, sorted from most specific to least specific.
+
+Parameters:
+ 
+- **`tag`** (`string`): The language tag that the returned language tags are related to.
+
+Returns a sorted array of related language tags, or an empty array if `tag` is malformed.
+
+Example:
+
+```js
+maplibregl.Diplomat.getRelatedLanguageTags("sr-RS").includes("sr-Cyrl");
+maplibregl.Diplomat.getRelatedLanguageTags("zh").includes("zh-Hans-CN");
+```
+
 ### `maplibregl.Diplomat.localizeStyle()`
 
 Updates each style layer's `text-field` value to match the given locales, upgrading any unlocalizable layer along the way.

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,8 @@ declare module "@americana/diplomat" {
 
   export function getLanguageFromURL(url: URL): string | null;
 
+  export function getRelatedLanguageTags(tag: string): string[];
+
   export function getLocales(): string[];
 
   export function getLocalizedNameExpression(

--- a/index.js
+++ b/index.js
@@ -10,6 +10,81 @@ export function getLanguageFromURL(url) {
 }
 
 /**
+ Returns the powerset of the given array.
+ */
+function powerset(array) {
+  return array.reduce(
+    (accum, value) => [...accum, ...accum.map((pick) => [...pick, value])],
+    [[]],
+  );
+}
+
+/**
+ Compatibility shim for `Intl.Locale.prototype.variants`.
+ */
+function getVariants(locale) {
+  return locale.variants ?? locale.minimize().baseName.match(/-([-\w]+)/)?.[1];
+}
+
+/**
+ Returns an array of the language tags related to the given language tag, sorted from most specific to least specific.
+ 
+ @param {string} tag - The language tag that the returned language tags are related to.
+ @returns {[string]} A sorted array of related language tags, or an empty array if `tag` is malformed.
+ */
+export function getRelatedLanguageTags(tag) {
+  let locale;
+  try {
+    locale = new Intl.Locale(tag);
+  } catch {
+    return [];
+  }
+
+  let maximized = locale.maximize();
+  // The subtags and extensions used in OSM name:*=* subkeys.
+  let quals = [
+    maximized.script,
+    maximized.region,
+    getVariants(maximized),
+    maximized.numberingSystem,
+  ].filter((q) => q);
+  // Get all the combinations of components and convert them to language tags.
+  let tags = powerset(quals).map((quals) =>
+    [maximized.language, ...quals].join("-"),
+  );
+
+  // Add the original language tag, in case maximizing it dropped miscellaneous extensions.
+  tags.push(locale + "");
+  tags.push(locale.baseName);
+
+  // Validate each of the language tags.
+  let locales = tags
+    .map((tag) => {
+      try {
+        return new Intl.Locale(tag);
+      } catch {}
+    })
+    .filter((l) => l);
+
+  // Sort the locales from most specific to least specific.
+  let scoreLocale = (locale) => {
+    let tag = locale + "";
+    let score = 0;
+    score += tag.length ?? 0;
+    score += tag.split("-").length ?? 0;
+    // Prioritize variants, which are more specific than script and region.
+    score += getVariants(locale)?.length ?? 0;
+    // Prioritize extensions, which Intl.Locale.prototype.maximize can’t maximize.
+    score += tag.match(/(?:-[tx]-|-u-\w\w-)\w+/)?.[0]?.length ?? 0;
+    return score;
+  };
+  locales.sort((a, b) => scoreLocale(b) - scoreLocale(a));
+
+  let validTags = locales.map((l) => l + "");
+  return [...new Set(validTags)];
+}
+
+/**
  * Returns the languages that the user prefers.
  */
 export function getLocales() {
@@ -17,27 +92,10 @@ export function getLocales() {
   let parameter = getLanguageFromURL(window.location)?.split(",");
   // Fall back to the user's language preference.
   let userLocales = parameter ?? navigator.languages ?? [navigator.language];
-  let locales = [];
-  let localeSet = new Set(); // avoid duplicates
-  for (let locale of userLocales) {
-    // Add progressively less specific variants of each user-specified locale.
-    let components = locale.split("-");
-    while (components.length > 0) {
-      let parent = components.join("-");
-      try {
-        // Preflight the parent locale in case it’s incomplete like `en-x`.
-        new Intl.Locale(parent);
-        if (!localeSet.has(parent)) locales.push(parent);
-        localeSet.add(parent);
-      } catch {}
-      components.pop();
-      // A Unicode extension like -u-nu must be followed by another subtag.
-      if (components.at(-1)?.length === 2 && components.at(-2) === "u") {
-        components.pop();
-      }
-    }
-  }
-  return locales;
+  // Get a full fallback list.
+  let tags = userLocales.flatMap((l) => getRelatedLanguageTags(l));
+
+  return [...new Set(tags)];
 }
 
 const defaultUnlocalizedNameProperty = "name";

--- a/index.spec.mjs
+++ b/index.spec.mjs
@@ -7,6 +7,7 @@ import {
   getLocalizedCountryNameExpression,
   getLocalizedCountryNames,
   getLocalizedNameExpression,
+  getRelatedLanguageTags,
   listValuesExpression,
   localizeLayers,
   localizedName,
@@ -65,6 +66,57 @@ describe("getLanguageFromURL", function () {
   });
 });
 
+describe("getRelatedLanguageTags", function () {
+  it("maximizes the locale", function () {
+    assert.deepEqual(getRelatedLanguageTags("zh"), [
+      "zh-Hans-CN",
+      "zh-Hans",
+      "zh-CN",
+      "zh",
+    ]);
+  });
+  it("progressively minimizes the locale", function () {
+    assert.deepEqual(getRelatedLanguageTags("zh-Hant-TW"), [
+      "zh-Hant-TW",
+      "zh-Hant",
+      "zh-TW",
+      "zh",
+    ]);
+  });
+  it("preserves the original locale", function () {
+    assert(getRelatedLanguageTags("zh-TW").includes("zh-TW"));
+  });
+  it("prefers extended locales over nonextended locales", function () {
+    const t = getRelatedLanguageTags("en-t-zh");
+    assert(t.includes("en-t-zh"));
+    assert(t.includes("en-Latn-US"));
+    assert(t.indexOf("en-t-zh") < t.indexOf("en-Latn-US"));
+
+    const nu = getRelatedLanguageTags("zh-u-nu-hant");
+    assert(nu.includes("zh-u-nu-hant"));
+    assert(nu.includes("zh-Hans-CN"));
+    assert(nu.indexOf("zh-u-nu-hant") < nu.indexOf("zh-Hans-CN"));
+
+    const sd = getRelatedLanguageTags("en-u-sd-usnc");
+    assert(sd.includes("en-u-sd-usnc"));
+    assert(sd.includes("en-Latn-US"));
+    assert(sd.indexOf("en-u-sd-usnc") < sd.indexOf("en-Latn-US"));
+
+    const x = getRelatedLanguageTags("fr-x-gallo");
+    assert(x.includes("fr-x-gallo"));
+    assert(x.includes("fr-Latn-FR"));
+    assert(x.indexOf("fr-x-gallo") < x.indexOf("fr-Latn-FR"));
+  });
+  it("prefers subtag over supertag", function () {
+    const related = getRelatedLanguageTags("es-fonipa");
+    assert(related.includes("es-Latn-ES-fonipa"));
+    assert(related.includes("es-fonipa"));
+    assert(related.includes("es-Latn-ES"));
+    assert(related.indexOf("es-Latn-ES-fonipa") < related.indexOf("es-fonipa"));
+    assert(related.indexOf("es-fonipa") < related.indexOf("es-Latn-ES"));
+  });
+});
+
 describe("getLocales", function () {
   beforeEach(function () {
     global.window = {};
@@ -96,26 +148,26 @@ describe("getLocales", function () {
       writable: true,
       configurable: true,
     });
-    assert.deepEqual(getLocales(), ["tlh-UN", "tlh", "ase"]);
+    assert.deepEqual(getLocales(), [
+      "tlh-UN",
+      "tlh",
+      "ase-Sgnw-US",
+      "ase-Sgnw",
+      "ase-US",
+      "ase",
+    ]);
   });
   it("gets locales from the URL", function () {
     window.location = new URL(
       "http://localhost:1776/#map=1/2/3&language=tlh-UN,ase",
     );
-    assert.deepEqual(getLocales(), ["tlh-UN", "tlh", "ase"]);
-    window.location = new URL(
-      "http://localhost:1776/#map=1/2/3&language=en-t-zh,zh-u-nu-hant,en-u-sd-usnc,es-fonipa,fr-x-gallo",
-    );
     assert.deepEqual(getLocales(), [
-      "en-t-zh",
-      "en",
-      "zh-u-nu-hant",
-      "zh",
-      "en-u-sd-usnc",
-      "es-fonipa",
-      "es",
-      "fr-x-gallo",
-      "fr",
+      "tlh-UN",
+      "tlh",
+      "ase-Sgnw-US",
+      "ase-Sgnw",
+      "ase-US",
+      "ase",
     ]);
   });
 });


### PR DESCRIPTION
Added the `getRelatedLanguageTags()` method for getting all the related variations of a given language tag. The current locales now include all these variations. Instead of calling `Intl.Locale.prototype.minimize()` directly, this implementation generates the powerset of language tags that are less specific than the maximized language tag.

Fixes #24.