### PR TITLE
Replace tokenizer with string recombination

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ All localization is subject to the availability of localized names in the map da
 
 ## Requirements
 
-Diplomat is compatible with applications using MapLibre GL&nbsp;JS v5.13.0 and above.
+Diplomat is compatible with applications using MapLibre GL&nbsp;JS v5.22.0 and above.
 
 The stylesheet must use the newer [expression](https://maplibre.org/maplibre-style-spec/expressions/) syntax; [legacy style functions](https://maplibre.org/maplibre-style-spec/deprecations/#function) are not supported. The stylesheet’s sources must conform to [Diplomat’s schema](#schema). Several popular vector tilesets already conform to this schema, including:
 
@@ -116,7 +116,7 @@ Diplomat can manipulate any GeoJSON or vector tile source, as long as it include
 
 For compatibility with the [OpenMapTiles](https://openmaptiles.org/schema/) schema, `name_en` and `name_de` are also recognized as alternatives to `name:en` and `name:de` for English and German, respectively, but only in the `transportation_name` layer. For performance reasons, Diplomat does not look for this format by default for any other language or layer.
 
-Each of the supported properties may be set to a list of values separated by [semicolons](https://wiki.openstreetmap.org/wiki/Semi-colon_value_separator). For example, if a place speaks both English and French, `name` should be `English Name;French Name`. Similarly, if a landmark has three equally common names in Spanish, regardless of dialect, `name:es` should be `Nombre Uno;Nombre Dos;Nombre Tres`. In the rare case that a single name contains a semicolon, it should be escaped as a double semicolon (`;;`).
+Each of the supported properties may be set to a list of values separated by [semicolons](https://wiki.openstreetmap.org/wiki/Semi-colon_value_separator). For example, if a place speaks both English and French, `name` should be `English Name;French Name`. Similarly, if a landmark has three equally common names in Spanish, regardless of dialect, `name:es` should be `Nombre Uno;Nombre Dos;Nombre Tres`. The list can contain an unlimited number of values. In the rare case that a single name contains a semicolon, it should be escaped as a double semicolon (`;;`).
 
 ## API
 
@@ -243,7 +243,7 @@ maplibregl.Diplomat.getLocales().includes("en");
 Returns an array of the language tags related to the given language tag, sorted from most specific to least specific.
 
 Parameters:
- 
+
 - **`tag`** (`string`): The language tag that the returned language tags are related to.
 
 Returns a sorted array of related language tags, or an empty array if `tag` is malformed.

--- a/index.js
+++ b/index.js
@@ -311,147 +311,6 @@ export function localizeLayers(layers, locales = getLocales(), options = {}) {
 }
 
 /**
- * Recursively scans a semicolon-delimited value list, replacing a finite number
- * of semicolons with a separator, starting from the given index.
- *
- * This expression nests recursively by the maximum number of replacements. Take
- * special care to minimize this limit, which exponentially increases the length
- * of a property value in JSON. Excessive nesting causes acute performance
- * problems when loading the style.
- *
- * The returned expression can be complex, so use it only once within a property
- * value. To reuse the evaluated value, bind it to a variable in a let
- * expression.
- *
- * @param list The overall string expression to search within.
- * @param separator A string to insert after the value, or an expression that
- *  evaluates to this string.
- * @param listStart A zero-based index into the list at which the search begins.
- * @param numReplacements The maximum number of replacements remaining.
- */
-function listValueExpression(
-  list,
-  separator,
-  valueToOmit,
-  listStart,
-  numReplacements,
-) {
-  let asIs = ["slice", list, listStart];
-  if (numReplacements <= 0) {
-    return asIs;
-  }
-
-  let iteration = numReplacements;
-  let rawSeparator = ";";
-  let needleStartVariable = `${variablePrefix}__needleStart${iteration}`;
-  let needleEndVariable = `${variablePrefix}__needleEnd${iteration}`;
-  let valueVariable = `${variablePrefix}__value${iteration}`;
-  let lookaheadVariable = `${variablePrefix}__lookahead${iteration}`;
-  let nextListStartVariable = `${variablePrefix}__nextListStart${iteration}`;
-  return [
-    "let",
-    needleStartVariable,
-    ["index-of", rawSeparator, list, listStart],
-    [
-      "case",
-      [">=", ["var", needleStartVariable], 0],
-      // Found a semicolon.
-      [
-        "let",
-        valueVariable,
-        ["slice", list, listStart, ["var", needleStartVariable]],
-        needleEndVariable,
-        ["+", ["var", needleStartVariable], rawSeparator.length],
-        [
-          "concat",
-          // Start with everything before the semicolon unless it's the value to
-          // omit.
-          [
-            "case",
-            ["==", ["var", valueVariable], valueToOmit],
-            "",
-            ["var", valueVariable],
-          ],
-          [
-            "let",
-            lookaheadVariable,
-            // Look ahead by one character.
-            [
-              "slice",
-              list,
-              ["var", needleEndVariable],
-              ["+", ["var", needleEndVariable], rawSeparator.length],
-            ],
-            [
-              "let",
-              // Skip past the current value and semicolon for any subsequent
-              // searches.
-              nextListStartVariable,
-              [
-                "+",
-                ["var", needleEndVariable],
-                // Also skip past any escaped semicolon or space padding.
-                [
-                  "match",
-                  ["var", lookaheadVariable],
-                  [rawSeparator, " "],
-                  rawSeparator.length,
-                  0,
-                ],
-              ],
-              [
-                "case",
-                // If the only remaining value is the value to omit, stop
-                // scanning.
-                [
-                  "==",
-                  ["slice", list, ["var", nextListStartVariable]],
-                  valueToOmit,
-                ],
-                "",
-                [
-                  "concat",
-                  [
-                    "case",
-                    // If the lookahead character is another semicolon, append
-                    // an unescaped semicolon.
-                    ["==", ["var", lookaheadVariable], rawSeparator],
-                    rawSeparator,
-                    // Otherwise, if the value is the value to omit, do nothing.
-                    ["==", ["var", valueVariable], valueToOmit],
-                    "",
-                    // Otherwise, append the passed-in separator.
-                    separator,
-                  ],
-                  // Recurse for the next value in the value list.
-                  listValueExpression(
-                    list,
-                    separator,
-                    valueToOmit,
-                    ["var", nextListStartVariable],
-                    numReplacements - 1,
-                  ),
-                ],
-              ],
-            ],
-          ],
-        ],
-      ],
-      // No semicolons left in the string, so stop looking and append the value as is.
-      asIs,
-    ],
-  ];
-}
-
-/**
- * Maximum number of values in a semicolon-delimited list of values.
- *
- * Increasing this constant deepens recursion for replacing delimiters in the
- * list, potentially affecting style loading performance.
- */
-const maxValueListLength = 3;
-
-/**
  * Returns an expression interpreting the given string as a list of tag values,
  * pretty-printing the standard semicolon delimiter with the given separator.
  *
@@ -468,22 +327,85 @@ const maxValueListLength = 3;
  * @returns {Expression}
  */
 export function listValuesExpression(valueList, separator, valueToOmit) {
-  let maxSeparators = maxValueListLength - 1;
-  let valueListVariable = `${variablePrefix}__valueList`;
-  let valueToOmitVariable = `${variablePrefix}__valueToOmit`;
+  // Replace the ;; escape sequence with a placeholder sequence unlikely to
+  // legitimately occur inside a value or separator.
+  const objReplacementChar = "\x91\ufffc\x92"; // https://overpass-turbo.eu/s/1pJx
+  let escapedValueList = [
+    "join",
+    ["split", valueList, ";;"],
+    objReplacementChar,
+  ];
+
+  // Collapse any space following the delimiter.
+  let collapsedValueList = ["join", ["split", escapedValueList, "; "], ";"];
+
+  let valuesVariable = `${variablePrefix}__values`;
+  let omissionIndexVariable = `${variablePrefix}__omissionIndex`;
+  let abridgedValuesVariable = `${variablePrefix}__abridgedValues`;
   return [
     "let",
-    valueListVariable,
-    valueList,
-    valueToOmitVariable,
-    valueToOmit || ";",
-    listValueExpression(
-      ["var", valueListVariable],
-      separator,
-      ["var", valueToOmitVariable],
-      0,
-      maxSeparators,
-    ),
+    valuesVariable,
+    ["split", collapsedValueList, ";"],
+    [
+      "let",
+      omissionIndexVariable,
+      valueToOmit ? ["index-of", valueToOmit, ["var", valuesVariable]] : -1,
+      [
+        "let",
+        abridgedValuesVariable,
+        [
+          "match",
+          ["var", omissionIndexVariable],
+          -1,
+          // Nothing to elide.
+          ["join", ["var", valuesVariable], separator],
+          // Produce the items before and after the omission index, eliding the value at that index.
+          [
+            "concat",
+            [
+              "join",
+              [
+                "slice",
+                ["var", valuesVariable],
+                0,
+                ["var", omissionIndexVariable],
+              ],
+              separator,
+            ],
+            // Leave only a separator in place of the omitted item, unless it’s at either end of the list.
+            [
+              "case",
+              [
+                "any",
+                ["==", ["var", omissionIndexVariable], 0],
+                [
+                  "==",
+                  ["var", omissionIndexVariable],
+                  ["-", ["length", ["var", valuesVariable]], 1],
+                ],
+              ],
+              "",
+              separator,
+            ],
+            [
+              "join",
+              [
+                "slice",
+                ["var", valuesVariable],
+                ["+", ["var", omissionIndexVariable], 1],
+              ],
+              separator,
+            ],
+          ],
+        ],
+        // Unescape any escaped semicolons.
+        [
+          "join",
+          ["split", ["var", abridgedValuesVariable], objReplacementChar],
+          ";",
+        ],
+      ],
+    ],
   ];
 }
 

--- a/index.spec.mjs
+++ b/index.spec.mjs
@@ -603,12 +603,13 @@ describe("localizedNameWithLocalGloss", function () {
       "Null Island",
       "Terra Nullius • 空虛島",
     );
+    // Looks silly, but this could be an intentional way of emphasizing that all three of the usual local languages call it the same. Otherwise, this is a tagging error that we don’t need to paper over.
     expectGloss(
       "en",
       "Null Island",
       "Null Island;Null Island;Null Island",
       "Null Island",
-      "",
+      "Null Island • Null Island",
     );
   });
 });
@@ -675,21 +676,21 @@ describe("listValuesExpression", function () {
     );
   });
 
-  it("lists a maximum number of values", function () {
-    // https://www.openstreetmap.org/node/9816809799
+  it("lists many values", function () {
+    // https://www.openstreetmap.org/node/9816809799/history/1
     assert.strictEqual(
       evaluatedExpression(
         "马岔河村;菜园村;刘灿东村;后于口村;王石楼村;李岔河村;岔河新村;富康新村;前鱼口村",
         "、",
       ),
-      "马岔河村、菜园村、刘灿东村;后于口村;王石楼村;李岔河村;岔河新村;富康新村;前鱼口村",
+      "马岔河村、菜园村、刘灿东村、后于口村、王石楼村、李岔河村、岔河新村、富康新村、前鱼口村",
     );
     assert.strictEqual(
       evaluatedExpression(
         "one;two;three;four;five;six;seven;eight;nine;ten",
         ", ",
       ),
-      "one, two, three;four;five;six;seven;eight;nine;ten",
+      "one, two, three, four, five, six, seven, eight, nine, ten",
     );
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.4.0",
       "license": "CC0-1.0",
       "devDependencies": {
-        "@maplibre/maplibre-gl-style-spec": "^24.3.1",
+        "@maplibre/maplibre-gl-style-spec": "^24.8.1",
         "esbuild": "0.28.0",
         "open": "^11.0.0",
         "prettier": "^3.6.2",
@@ -17,7 +17,7 @@
         "typescript": "^6.0.2"
       },
       "peerDependencies": {
-        "maplibre-gl": "^5.13.0"
+        "maplibre-gl": "^5.22.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -462,20 +462,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@mapbox/geojson-rewind": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
-      "integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "get-stream": "^6.0.1",
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "geojson-rewind": "geojson-rewind"
-      }
-    },
     "node_modules/@mapbox/jsonlint-lines-primitives": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
@@ -492,9 +478,9 @@
       "peer": true
     },
     "node_modules/@mapbox/tiny-sdf": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.7.tgz",
-      "integrity": "sha512-25gQLQMcpivjOSA40g3gO6qgiFPDpWRoMfd+G/GoppPIeP6JDaMMkMrEJnMZhKyyS6iKwVt5YKu02vCUyJM3Ug==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.1.0.tgz",
+      "integrity": "sha512-uFJhNh36BR4OCuWIEiWaEix9CA2WzT6CAIcqVjWYpnx8+QDtS+oC4QehRrx5cX4mgWs37MmKnwUejeHxVymzNg==",
       "license": "BSD-2-Clause",
       "peer": true
     },
@@ -526,6 +512,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@maplibre/geojson-vt": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.1.0.tgz",
+      "integrity": "sha512-2eIY4gZxeKIVOZVNkAMb+5NgXhgsMQpOveTQAvnp53LYqHGJZDidk7Ew0Tged9PThidpbS+NFTh0g4zivhPDzQ==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "kdbush": "^4.0.2"
+      }
+    },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
       "version": "24.8.1",
       "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.8.1.tgz",
@@ -547,9 +543,9 @@
       }
     },
     "node_modules/@maplibre/mlt": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.1.0.tgz",
-      "integrity": "sha512-anR8WxKIgZUJQLlZtID0v06wd9Q//9K/6lLLU3dOzmeO/xLEzAwmEqP24jEnEUBcnZGkM4vidz9H6Q4guNAAlw==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.1.9.tgz",
+      "integrity": "sha512-g/tD8EYJB97udq33ipuJ9a4Q7fcbZnTEnUrgnEc/tLMmEL+zaCbR+X5fkDBO2dgpaAMsLH179qE3UXg2N0Nc/g==",
       "license": "(MIT OR Apache-2.0)",
       "peer": true,
       "dependencies": {
@@ -557,20 +553,27 @@
       }
     },
     "node_modules/@maplibre/vt-pbf": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.0.3.tgz",
-      "integrity": "sha512-YsW99BwnT+ukJRkseBcLuZHfITB4puJoxnqPVjo72rhW/TaawVYsgQHcqWLzTxqknttYoDpgyERzWSa/XrETdA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.0.tgz",
+      "integrity": "sha512-jIvp8F5hQCcreqOOpEt42TJMUlsrEcpf/kI1T2v85YrQRV6PPXUcEXUg5karKtH6oh47XJZ4kHu56pUkOuqA7w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@mapbox/point-geometry": "^1.1.0",
         "@mapbox/vector-tile": "^2.0.4",
-        "@types/geojson-vt": "3.2.5",
+        "@maplibre/geojson-vt": "^5.0.4",
+        "@types/geojson": "^7946.0.16",
         "@types/supercluster": "^7.1.3",
-        "geojson-vt": "^4.0.2",
         "pbf": "^4.0.1",
         "supercluster": "^8.0.1"
       }
+    },
+    "node_modules/@maplibre/vt-pbf/node_modules/@maplibre/geojson-vt": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-5.0.4.tgz",
+      "integrity": "sha512-KGg9sma45S+stfH9vPCJk1J0lSDLWZgCT9Y8u8qWZJyjFlP8MNP1WGTxIMYJZjDvVT3PDn05kN1C95Sut1HpgQ==",
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -616,16 +619,6 @@
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/@types/geojson-vt": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz",
-      "integrity": "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/geojson": "*"
-      }
     },
     "node_modules/@types/supercluster": {
       "version": "7.1.3",
@@ -867,26 +860,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/geojson-vt": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
-      "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==",
-      "license": "ISC",
-      "peer": true
-    },
-    "node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/gl-matrix": {
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
@@ -1074,34 +1047,30 @@
       "peer": true
     },
     "node_modules/maplibre-gl": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.13.0.tgz",
-      "integrity": "sha512-UsIVP34rZdM4TjrjhwBAhbC3HT7AzFx9p/draiAPlLr8/THozZF6WmJnZ9ck4q94uO55z7P7zoGCh+AZVoagsQ==",
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.24.0.tgz",
+      "integrity": "sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==",
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
-        "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
         "@mapbox/point-geometry": "^1.1.0",
-        "@mapbox/tiny-sdf": "^2.0.7",
+        "@mapbox/tiny-sdf": "^2.1.0",
         "@mapbox/unitbezier": "^0.0.1",
         "@mapbox/vector-tile": "^2.0.4",
         "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^24.3.1",
-        "@maplibre/mlt": "^1.1.0",
-        "@maplibre/vt-pbf": "^4.0.3",
+        "@maplibre/geojson-vt": "^6.1.0",
+        "@maplibre/maplibre-gl-style-spec": "^24.8.1",
+        "@maplibre/mlt": "^1.1.8",
+        "@maplibre/vt-pbf": "^4.3.0",
         "@types/geojson": "^7946.0.16",
-        "@types/geojson-vt": "3.2.5",
-        "@types/supercluster": "^7.1.3",
         "earcut": "^3.0.2",
-        "geojson-vt": "^4.0.2",
         "gl-matrix": "^3.4.4",
         "kdbush": "^4.0.2",
         "murmurhash-js": "^1.0.0",
         "pbf": "^4.0.1",
         "potpack": "^2.1.0",
         "quickselect": "^3.0.0",
-        "supercluster": "^8.0.1",
         "tinyqueue": "^3.0.0"
       },
       "engines": {
@@ -1293,9 +1262,9 @@
       }
     },
     "node_modules/protocol-buffers-schema": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
       "license": "MIT",
       "peer": true
     },

--- a/package.json
+++ b/package.json
@@ -42,10 +42,10 @@
     "test": "node --import ./test/setup.mjs --test 'index.spec.mjs'"
   },
   "peerDependencies": {
-    "maplibre-gl": "^5.13.0"
+    "maplibre-gl": "^5.22.0"
   },
   "devDependencies": {
-    "@maplibre/maplibre-gl-style-spec": "^24.3.1",
+    "@maplibre/maplibre-gl-style-spec": "^24.8.1",
     "esbuild": "0.28.0",
     "open": "^11.0.0",
     "prettier": "^3.6.2",


### PR DESCRIPTION
Replaced the elaborate custom string tokenizer with a simpler set of nested split, join, and slice operations. This implementation supports an unbounded number of items in a semicolon-delimited list, up from a maximum of three that was originally imposed to keep memory consumption and CPU usage to an acceptable level.

This new implementation relies on the `split` and `join` expression operators added in maplibre/maplibre-style-spec#1518, so Diplomat now requires MapLibre GL&nbsp;JS v5.22 or above.

Fixes #33.